### PR TITLE
Use two spaces as default indention instead of tab

### DIFF
--- a/Sources/Application/Kysect.Zeya.ProjectSystemIntegration/Tools/ExtendedSyntaxFactory.cs
+++ b/Sources/Application/Kysect.Zeya.ProjectSystemIntegration/Tools/ExtendedSyntaxFactory.cs
@@ -6,6 +6,8 @@ namespace Kysect.Zeya.ProjectSystemIntegration.Tools;
 
 public static class ExtendedSyntaxFactory
 {
+    public const string DefaultIndention = "  ";
+
     public static XmlNameSyntax XmlName(string name)
     {
         return SyntaxFactory.XmlName(null, SyntaxFactory.XmlNameToken(name, null, null));
@@ -73,13 +75,12 @@ public static class ExtendedSyntaxFactory
         return SyntaxFactory.XmlElement(startTagSyntax, SyntaxFactory.List<SyntaxNode>(SyntaxFactory.XmlText(SyntaxFactory.XmlTextLiteralToken(value, null, null))), endTagSyntax);
     }
 
-    // TODO: specify indention
     public static SyntaxTrivia XmlWhiteIndention(int depth)
     {
         var sb = new StringBuilder(Environment.NewLine);
 
-        for (var i = 0; i < depth; i++)
-            sb = sb.Append('\t');
+        for (int i = 0; i < depth; i++)
+            sb = sb.Append(DefaultIndention);
 
         return SyntaxFactory.WhitespaceTrivia(sb.ToString());
     }

--- a/Sources/Tests/Kysect.Zeya.Tests/ExtendedSyntaxFactoryTests.cs
+++ b/Sources/Tests/Kysect.Zeya.Tests/ExtendedSyntaxFactoryTests.cs
@@ -11,8 +11,8 @@ public class ExtendedSyntaxFactoryTests
     {
         var expected = $"""
 
-                        {'\t'}<Name>
-                        {'\t'}</Name>
+                          <Name>
+                          </Name>
                         """;
         var result = ExtendedSyntaxFactory.XmlElement("Name", 1);
 
@@ -25,9 +25,9 @@ public class ExtendedSyntaxFactoryTests
     {
         var expected = $"""
 
-                        {'\t'}<Name>
-                        {'\t'}{'\t'}<Key>Value</Key>
-                        {'\t'}</Name>
+                          <Name>
+                            <Key>Value</Key>
+                          </Name>
                         """;
 
         var result = ExtendedSyntaxFactory.XmlElement("Name", 1).AddChild(ExtendedSyntaxFactory.PropertyGroupParameter("Key", "Value"));

--- a/Sources/Tests/Kysect.Zeya.Tests/ValidationRuleFixers/SourceCode/CentralPackageManagerEnabledValidationRuleFixerTests.cs
+++ b/Sources/Tests/Kysect.Zeya.Tests/ValidationRuleFixers/SourceCode/CentralPackageManagerEnabledValidationRuleFixerTests.cs
@@ -59,12 +59,12 @@ public class CentralPackageManagerEnabledValidationRuleFixerTests
 
         var expectedDotnetPackageContent = $"""
                                            <Project>
-                                           {'\t'}<PropertyGroup>
-                                           {'\t'}{'\t'}<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                           {'\t'}</PropertyGroup>
-                                           {'\t'}<ItemGroup>
-                                           {'\t'}{'\t'}<PackageVersion Include="FluentAssertions" Version="6.12.0" />
-                                           {'\t'}</ItemGroup>
+                                             <PropertyGroup>
+                                               <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                             </PropertyGroup>
+                                             <ItemGroup>
+                                               <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+                                             </ItemGroup>
                                            </Project>
                                            """;
 
@@ -112,12 +112,12 @@ public class CentralPackageManagerEnabledValidationRuleFixerTests
         // TODO: implement formatting rule
         var expectedDotnetPackageContent = $"""
                                            <Project>
-                                           {'\t'}<PropertyGroup>
-                                           {'\t'}{'\t'}<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                           {'\t'}</PropertyGroup>
-                                           {'\t'}<ItemGroup>
-                                           {'\t'}{'\t'}<PackageVersion Include="FluentAssertions" Version="6.12.0" />
-                                           {'\t'}</ItemGroup>
+                                             <PropertyGroup>
+                                               <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                                             </PropertyGroup>
+                                             <ItemGroup>
+                                               <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+                                             </ItemGroup>
                                            </Project>
                                            """;
 

--- a/Sources/Tests/Kysect.Zeya.Tests/ValidationRuleFixers/SourceCode/RequiredPackagesAddedValidationRuleFixerTests.cs
+++ b/Sources/Tests/Kysect.Zeya.Tests/ValidationRuleFixers/SourceCode/RequiredPackagesAddedValidationRuleFixerTests.cs
@@ -45,9 +45,9 @@ public class RequiredPackagesAddedValidationRuleFixerTests
     {
         const string expectedDirectoryBuildPropsFile = """
                                                        <Project>
-                                                       	<ItemGroup>
-                                                       		<PackageReference Include="RequiredPackage" />
-                                                       	</ItemGroup>
+                                                         <ItemGroup>
+                                                           <PackageReference Include="RequiredPackage" />
+                                                         </ItemGroup>
                                                        </Project>
                                                        """;
 
@@ -69,9 +69,9 @@ public class RequiredPackagesAddedValidationRuleFixerTests
 
         const string expectedDirectoryBuildPropsFile = """
                                                        <Project>
-                                                       	<ItemGroup>
-                                                       		<PackageReference Include="RequiredPackage" />
-                                                       	</ItemGroup>
+                                                         <ItemGroup>
+                                                           <PackageReference Include="RequiredPackage" />
+                                                         </ItemGroup>
                                                        </Project>
                                                        """;
 


### PR DESCRIPTION
Visual studio do not use tabs in .csproj and Directory.*.props. So it's better to use two spaces to prevent future refactor by Visual studio.